### PR TITLE
Move to new SQLitePCLRaw package

### DIFF
--- a/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
+++ b/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
@@ -35,8 +35,8 @@
   </PropertyGroup>
 
   <ItemGroup>    
-    <PackageReference Include="sqlite-net-base" Version="1.10.196-beta" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
+    <PackageReference Include="sqlite-net-base" Version="1.11.272-beta" />
+    <PackageReference Include="sqlitepclraw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
 		<None Include="..\..\..\nuget.png" PackagePath="nuget.png" Pack="true" />

--- a/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
+++ b/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>    
     <PackageReference Include="sqlite-net-base" Version="1.11.272-beta" />
-    <PackageReference Include="sqlitepclraw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="sqlitepclraw.config.e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
 		<None Include="..\..\..\nuget.png" PackagePath="nuget.png" Pack="true" />

--- a/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
+++ b/src/SQLiteNetExtensions.Modern/SQLiteNetExtensions.Modern/SQLiteNetExtensions.csproj
@@ -9,7 +9,7 @@
 		<Authors>yurkinh</Authors>
 		<Copyright>Copyright © yurkinh and contributors</Copyright>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageVersion>3.0.0</PackageVersion>
+		<PackageVersion>3.1.0</PackageVersion>
 		<IsPackable>True</IsPackable>
 		<PackageProjectUrl>https://github.com/yurkinh/SQLiteNetExtensions.Modern</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/yurkinh/SQLiteNetExtensions.Modern</RepositoryUrl>


### PR DESCRIPTION
This change allows to use other sqlite providers as per 
[V3 Migration guide for SQLitePCLRaw](https://github.com/ericsink/SQLitePCL.raw/blob/main/v3.md)

Additionaly bumps `sqlite-net-base`.

This would be breaking change for some projects.

Dependency and version updates:

* Bumped the `PackageVersion` in `SQLiteNetExtensions.csproj` from `3.0.0` to `3.1.0` to reflect the new release.
* Updated the `sqlite-net-base` dependency from version `1.10.196-beta` to `1.11.272-beta`.
* Replaced the `SQLitePCLRaw.bundle_green` dependency (version `2.1.11`) with `sqlitepclraw.config.e_sqlite3` at version `3.0.3` for improved SQLite support.